### PR TITLE
Add -pthread to LIBS when detecting googletest (autotools)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@ AS_IF([test "x$with_gtest" != "xno"],
       AC_CHECK_HEADER([gtest/gtest.h],
          [AC_MSG_CHECKING([for library containing testing::InitGoogleTest])
           SAVELIBS=$LIBS
-          LIBS="$LIBS -lgtest"
+          LIBS="$LIBS -lgtest -pthread"
           AC_LINK_IFELSE(
               [AC_LANG_PROGRAM([
                   #include <gtest/gtest.h>


### PR DESCRIPTION
This is necessary on some systems (e.g., RHEL)